### PR TITLE
add info about securing webui to setting up application section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 Webui is on port 9091, the settings.json file in /config has extra settings not available in the webui. Stop the container before editing it or any changes won't be saved.
 
+## Securing the webui with a username/password.
+
+this requires 3 settings to be changed in the settings.json file.
+
+`Make sure the container is stopped before editing these settings.`
+
+`"rpc-authentication-required": true,` - check this, the default is false, change to true.
+
+`"rpc-username": "transmission",` substitute transmission for your chosen user name, this is just an example.
+
+`rpc-password` will be a hash starting with {, replace everything including the { with your chosen password, keeping the quotes.
+
+Transmission will convert it to a hash when you restart the container after making the above edits.
 
 ## Info
 
@@ -71,5 +84,6 @@ Webui is on port 9091, the settings.json file in /config has extra settings not 
 
 ## Versions
 
++ **23.09.16:** Add information about securing the webui to README..
 + **21.09.16:** Add curl package.
 + **07.09.16:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- put information about securing the webui with a password and username from
  linuxserver/transmission#8 into README
